### PR TITLE
KEP: Tier Shifts

### DIFF
--- a/data/mods/gen1expansionpack/formats-data.ts
+++ b/data/mods/gen1expansionpack/formats-data.ts
@@ -758,7 +758,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	golbat: {
 		randomBattleMoves: ["confuseray", "doubleedge", "hyperbeam", "megadrain"],
-		tier: "PU",
+		tier: "NFE",
 	},
 	oddish: {
 		randomBattleMoves: ["doubleedge", "sleeppowder"],
@@ -841,7 +841,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	primeape: {
 		randomBattleMoves: ["bodyslam", "rockslide", "submission"],
 		exclusiveMoves: ["counter", "hyperbeam", "hyperbeam"],
-		tier: "PU",
+		tier: "NFE",
 	},
 	growlithe: {
 		randomBattleMoves: ["bodyslam", "fireblast", "flamethrower", "reflect"],
@@ -862,7 +862,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		randomBattleMoves: ["blizzard", "surf"],
 		essentialMove: "amnesia",
 		exclusiveMoves: ["counter", "hypnosis", "hypnosis", "psychic"],
-		tier: "NU",
+		tier: "NFE",
 	},
 	poliwrath: {
 		randomBattleMoves: ["blizzard", "bodyslam", "earthquake", "submission"],
@@ -879,7 +879,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	kadabra: {
 		randomBattleMoves: ["psychic", "recover", "thunderwave"],
 		exclusiveMoves: ["counter", "reflect", "reflect", "seismictoss", "seismictoss"],
-		tier: "UU",
+		tier: "NFE",
 	},
 	alakazam: {
 		randomBattleMoves: ["psychic", "recover", "thunderwave"],
@@ -1031,13 +1031,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		randomBattleMoves: ["explosion", "megadrain", "nightshade", "psychic"],
 		essentialMove: "thunderbolt",
 		exclusiveMoves: ["confuseray", "hypnosis", "hypnosis"],
-		tier: "UU",
+		tier: "NFE",
 	},
 	haunterghost: {
 		randomBattleMoves: ["explosion", "megadrain", "nightshade", "psychic"],
 		essentialMove: "thunderbolt",
 		exclusiveMoves: ["confuseray", "hypnosis", "hypnosis"],
-		tier: "UU",
+		tier: "NFE",
 	},
 	gengar: {
 		randomBattleMoves: ["explosion", "megadrain", "nightshade", "psychic"],
@@ -1189,7 +1189,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mrmime: {
 		randomBattleMoves: ["psychic", "seismictoss", "thunderbolt", "thunderwave"],
-		tier: "NU", //jesus christ how horrifying (apparently?)
+		tier: "NU",
 	},
 	scyther: {
 		randomBattleMoves: ["agility", "hyperbeam", "slash", "swordsdance"],
@@ -1263,7 +1263,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		randomBattleMoves: ["blizzard", "thunderwave"],
 		essentialMove: "recover",
 		exclusiveMoves: ["doubleedge", "psychic", "thunderbolt", "triattack"],
-		tier: "NU",
+		tier: "LC",
 	},
 	omanyte: {
 		randomBattleMoves: ["bodyslam", "hydropump", "rest", "surf"],

--- a/data/mods/gen1expansionpack/formats-data.ts
+++ b/data/mods/gen1expansionpack/formats-data.ts
@@ -1253,7 +1253,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	jolteon: {
 		randomBattleMoves: ["bodyslam", "thunderbolt", "thunderwave"],
 		exclusiveMoves: ["agility", "agility", "doublekick", "pinmissile", "pinmissile"],
-		tier: "OU",
+		tier: "UU",
 	},
 	flareon: {
 		randomBattleMoves: ["bodyslam", "fireblast", "hyperbeam", "quickattack"],


### PR DESCRIPTION
Jolteon is the first of the old OU titans to fall from KEP, seeing very little usage and being about as viable as Gorochu. Sandy Shocks is too much!

I also moved a few Pokemon that were in vanilla RBY tiers to NFE and LC for consistency, and because these tiers will see rapid shifts that doesn't justify them staying the same. It's also more transparent for people wanting to play an expanded NFE or LC, which seems to be more popular than a KEP UU.