### PR TITLE
KEP: Tricules should have 45 Speed

### DIFF
--- a/data/mods/gen1expansionpack/pokedex.ts
+++ b/data/mods/gen1expansionpack/pokedex.ts
@@ -354,7 +354,7 @@ export const Pokedex: {[k: string]: ModdedSpeciesData} = {
 		gen: 1,
 		name: "Tricules",
 		types: ["Bug", "Steel"],
-		baseStats: {hp: 65, atk: 125, def: 140, spa: 55, spd: 55, spe: 85},
+		baseStats: {hp: 65, atk: 125, def: 140, spa: 55, spd: 55, spe: 45},
 		abilities: {},
 		prevo: "Pinsir",
 		evoLevel: 42,


### PR DESCRIPTION
It's based on its 1999-07-30 incarnation, with 140 Def, so 45 Speed should be there to match.

Src: https://tcrf.net/Development:Pok%C3%A9mon_Gold_and_Silver/Pok%C3%A9mon_Data/Cut_Pok%C3%A9mon#Purakkusu