### PR TITLE
Bug Fix: Fakemons Tera Types

### DIFF
--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -565,6 +565,12 @@ export class TeamValidator {
 			set.teraType = species.types[0];
 		}
 
+		// fix pokepast.es bug with Fakemons having their Tera type auto-set to ???
+		if (set.teraType === '???') {
+			set.teraType = species.types[0];
+			
+		}
+
 		if (!set.level) set.level = ruleTable.defaultLevel;
 
 		let adjustLevel = ruleTable.adjustLevel;

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -568,7 +568,6 @@ export class TeamValidator {
 		// fix pokepast.es bug with Fakemons having their Tera type auto-set to ???
 		if (set.teraType === '???') {
 			set.teraType = species.types[0];
-			
 		}
 
 		if (!set.level) set.level = ruleTable.defaultLevel;


### PR DESCRIPTION
Fix for Fakemons Tera types being set as '???' when it is the same as the primary type of the Mon. Getting the teambuilder itself to display the correct type is a little bit extra work, but this at least handles the issue of paste info being lost.