### PR TITLE
Revert Gen 6/7 stat changes (ADV Tradebacks)

### DIFF
--- a/data/mods/gen3tradebacks/pokedex.ts
+++ b/data/mods/gen3tradebacks/pokedex.ts
@@ -2209,8 +2209,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		"num": 39,
 		"name": "Jigglypuff",
 		"types": [
-				"Normal",
-				null
+				"Normal"
 		],
 		"genderRatio": {
 				"M": 0.25,
@@ -2264,8 +2263,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		"num": 40,
 		"name": "Wigglytuff",
 		"types": [
-				"Normal",
-				null
+				"Normal"
 		],
 		"genderRatio": {
 				"M": 0.25,
@@ -6918,8 +6916,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		"num": 122,
 		"name": "Mr. Mime",
 		"types": [
-				"Psychic",
-				null
+				"Psychic"
 		],
 		"baseStats": {
 				"hp": 40,
@@ -9835,8 +9832,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		"num": 174,
 		"name": "Igglybuff",
 		"types": [
-				"Normal",
-				null
+				"Normal"
 		],
 		"genderRatio": {
 				"M": 0.25,
@@ -9889,7 +9885,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		"num": 175,
 		"name": "Togepi",
 		"types": [
-				null
+				"Normal"
 		],
 		"genderRatio": {
 				"M": 0.875,
@@ -10334,8 +10330,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		"num": 183,
 		"name": "Marill",
 		"types": [
-				"Water",
-				null
+				"Water"
 		],
 		"baseStats": {
 				"hp": 70,
@@ -10391,8 +10386,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		"num": 184,
 		"name": "Azumarill",
 		"types": [
-				"Water",
-				null
+				"Water"
 		],
 		"baseStats": {
 				"hp": 100,
@@ -11829,7 +11823,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		"num": 209,
 		"name": "Snubbull",
 		"types": [
-				null
+				"Normal"
 		],
 		"genderRatio": {
 				"M": 0.25,
@@ -11884,7 +11878,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		"num": 210,
 		"name": "Granbull",
 		"types": [
-				null
+				"Normal"
 		],
 		"genderRatio": {
 				"M": 0.25,
@@ -15776,8 +15770,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		"num": 280,
 		"name": "Ralts",
 		"types": [
-				"Psychic",
-				null
+				"Psychic"
 		],
 		"baseStats": {
 				"hp": 28,
@@ -15832,8 +15825,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		"num": 281,
 		"name": "Kirlia",
 		"types": [
-				"Psychic",
-				null
+				"Psychic"
 		],
 		"baseStats": {
 				"hp": 38,
@@ -15890,8 +15882,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		"num": 282,
 		"name": "Gardevoir",
 		"types": [
-				"Psychic",
-				null
+				"Psychic"
 		],
 		"baseStats": {
 				"hp": 68,
@@ -16762,8 +16753,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		"num": 298,
 		"name": "Azurill",
 		"types": [
-				"Normal",
-				null
+				"Normal"
 		],
 		"genderRatio": {
 				"M": 0.25,
@@ -17038,8 +17028,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		"num": 303,
 		"name": "Mawile",
 		"types": [
-				"Steel",
-				null
+				"Steel"
 		],
 		"baseStats": {
 				"hp": 50,

--- a/data/mods/gen3tradebacks/pokedex.ts
+++ b/data/mods/gen3tradebacks/pokedex.ts
@@ -642,7 +642,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 				"hp": 60,
 				"atk": 45,
 				"def": 50,
-				"spa": 90,
+				"spa": 80,
 				"spd": 80,
 				"spe": 70
 		},
@@ -804,7 +804,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		],
 		"baseStats": {
 				"hp": 65,
-				"atk": 90,
+				"atk": 80,
 				"def": 40,
 				"spa": 45,
 				"spd": 80,
@@ -977,7 +977,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 				"def": 75,
 				"spa": 70,
 				"spd": 70,
-				"spe": 101
+				"spe": 91
 		},
 		"abilities": {
 				"0": "Keen Eye"
@@ -1319,7 +1319,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		],
 		"baseStats": {
 				"hp": 60,
-				"atk": 95,
+				"atk": 85,
 				"def": 69,
 				"spa": 65,
 				"spd": 79,
@@ -1374,9 +1374,9 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		"baseStats": {
 				"hp": 35,
 				"atk": 55,
-				"def": 40,
+				"def": 30,
 				"spa": 50,
-				"spd": 50,
+				"spd": 40,
 				"spe": 90
 		},
 		"abilities": {
@@ -1470,7 +1470,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 				"def": 55,
 				"spa": 90,
 				"spd": 80,
-				"spe": 110
+				"spe": 100
 		},
 		"abilities": {
 				"0": "Static",
@@ -1761,7 +1761,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		"gender": "F",
 		"baseStats": {
 				"hp": 90,
-				"atk": 92,
+				"atk": 82,
 				"def": 87,
 				"spa": 75,
 				"spd": 85,
@@ -1930,7 +1930,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		"gender": "M",
 		"baseStats": {
 				"hp": 81,
-				"atk": 102,
+				"atk": 92,
 				"def": 77,
 				"spa": 85,
 				"spd": 75,
@@ -2044,7 +2044,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 				"hp": 95,
 				"atk": 70,
 				"def": 73,
-				"spa": 95,
+				"spa": 85,
 				"spd": 90,
 				"spe": 60
 		},
@@ -2275,7 +2275,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 				"hp": 140,
 				"atk": 70,
 				"def": 45,
-				"spa": 85,
+				"spa": 75,
 				"spd": 50,
 				"spe": 45
 		},
@@ -2546,7 +2546,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 				"hp": 75,
 				"atk": 80,
 				"def": 85,
-				"spa": 110,
+				"spa": 100,
 				"spd": 90,
 				"spe": 50
 		},
@@ -2878,7 +2878,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		],
 		"baseStats": {
 				"hp": 35,
-				"atk": 100,
+				"atk": 80,
 				"def": 50,
 				"spa": 50,
 				"spd": 70,
@@ -3513,7 +3513,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		],
 		"baseStats": {
 				"hp": 90,
-				"atk": 95,
+				"atk": 85,
 				"def": 95,
 				"spa": 70,
 				"spd": 90,
@@ -3684,7 +3684,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 				"atk": 50,
 				"def": 45,
 				"spa": 135,
-				"spd": 95,
+				"spd": 85,
 				"spe": 120
 		},
 		"abilities": {
@@ -4010,7 +4010,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 				"atk": 105,
 				"def": 65,
 				"spa": 100,
-				"spd": 70,
+				"spd": 60,
 				"spe": 70
 		},
 		"abilities": {
@@ -4299,7 +4299,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		],
 		"baseStats": {
 				"hp": 80,
-				"atk": 120,
+				"atk": 110,
 				"def": 130,
 				"spa": 55,
 				"spd": 65,
@@ -4725,7 +4725,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		],
 		"baseStats": {
 				"hp": 52,
-				"atk": 90,
+				"atk": 65,
 				"def": 55,
 				"spa": 58,
 				"spd": 62,
@@ -4845,7 +4845,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 				"def": 70,
 				"spa": 60,
 				"spd": 60,
-				"spe": 110
+				"spe": 100
 		},
 		"abilities": {
 				"0": "Run Away",
@@ -5737,7 +5737,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 				"def": 70,
 				"spa": 80,
 				"spd": 80,
-				"spe": 150
+				"spe": 140
 		},
 		"abilities": {
 				"0": "Soundproof",
@@ -5852,7 +5852,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 				"atk": 95,
 				"def": 85,
 				"spa": 125,
-				"spd": 75,
+				"spd": 65,
 				"spe": 55
 		},
 		"abilities": {
@@ -9292,7 +9292,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 				"hp": 100,
 				"atk": 50,
 				"def": 50,
-				"spa": 86,
+				"spa": 76,
 				"spd": 96,
 				"spe": 70
 		},
@@ -9511,7 +9511,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 				"atk": 90,
 				"def": 70,
 				"spa": 60,
-				"spd": 70,
+				"spd": 60,
 				"spe": 40
 		},
 		"abilities": {
@@ -10225,7 +10225,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		"baseStats": {
 				"hp": 90,
 				"atk": 75,
-				"def": 85,
+				"def": 75,
 				"spa": 115,
 				"spd": 90,
 				"spe": 55
@@ -10286,7 +10286,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		"baseStats": {
 				"hp": 75,
 				"atk": 80,
-				"def": 95,
+				"def": 85,
 				"spa": 90,
 				"spd": 100,
 				"spe": 50
@@ -10398,7 +10398,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 				"hp": 100,
 				"atk": 50,
 				"def": 80,
-				"spa": 60,
+				"spa": 50,
 				"spd": 80,
 				"spe": 50
 		},
@@ -10674,7 +10674,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 				"atk": 55,
 				"def": 70,
 				"spa": 55,
-				"spd": 95,
+				"spd": 85,
 				"spe": 110
 		},
 		"abilities": {
@@ -11943,7 +11943,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		"baseStats": {
 				"hp": 65,
 				"atk": 95,
-				"def": 85,
+				"def": 75,
 				"spa": 55,
 				"spd": 55,
 				"spe": 85
@@ -12398,10 +12398,10 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 				"Rock"
 		],
 		"baseStats": {
-				"hp": 60,
+				"hp": 50,
 				"atk": 50,
 				"def": 120,
-				"spa": 90,
+				"spa": 80,
 				"spd": 80,
 				"spe": 30
 		},
@@ -12567,11 +12567,11 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 				"F": 0.75
 		},
 		"baseStats": {
-				"hp": 65,
+				"hp": 55,
 				"atk": 55,
-				"def": 95,
+				"def": 85,
 				"spa": 65,
-				"spd": 95,
+				"spd": 85,
 				"spe": 35
 		},
 		"abilities": {
@@ -12786,7 +12786,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 				"Flying"
 		],
 		"baseStats": {
-				"hp": 85,
+				"hp": 65,
 				"atk": 40,
 				"def": 70,
 				"spa": 80,
@@ -15064,7 +15064,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 				"hp": 60,
 				"atk": 70,
 				"def": 50,
-				"spa": 100,
+				"spa": 90,
 				"spd": 50,
 				"spe": 65
 		},
@@ -15618,7 +15618,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 				"hp": 60,
 				"atk": 85,
 				"def": 60,
-				"spa": 75,
+				"spa": 50,
 				"spd": 50,
 				"spe": 125
 		},
@@ -15727,7 +15727,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 				"hp": 60,
 				"atk": 50,
 				"def": 100,
-				"spa": 95,
+				"spa": 85,
 				"spd": 70,
 				"spe": 65
 		},
@@ -16015,9 +16015,9 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 				"hp": 70,
 				"atk": 60,
 				"def": 62,
-				"spa": 100,
+				"spa": 80,
 				"spd": 82,
-				"spe": 80
+				"spe": 60
 		},
 		"abilities": {
 				"0": "Intimidate"
@@ -16609,7 +16609,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 				"atk": 91,
 				"def": 63,
 				"spa": 91,
-				"spd": 73,
+				"spd": 63,
 				"spe": 68
 		},
 		"abilities": {
@@ -16937,7 +16937,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 				"def": 65,
 				"spa": 55,
 				"spd": 55,
-				"spe": 90
+				"spe": 70
 		},
 		"abilities": {
 				"0": "Cute Charm"
@@ -17611,9 +17611,9 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		"baseStats": {
 				"hp": 65,
 				"atk": 73,
-				"def": 75,
+				"def": 55,
 				"spa": 47,
-				"spd": 85,
+				"spd": 75,
 				"spe": 85
 		},
 		"abilities": {
@@ -17666,9 +17666,9 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		"baseStats": {
 				"hp": 65,
 				"atk": 47,
-				"def": 75,
+				"def": 55,
 				"spa": 73,
-				"spd": 85,
+				"spd": 75,
 				"spe": 85
 		},
 		"abilities": {
@@ -18933,7 +18933,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		],
 		"gender": "N",
 		"baseStats": {
-				"hp": 90,
+				"hp": 70,
 				"atk": 55,
 				"def": 65,
 				"spa": 95,
@@ -18986,7 +18986,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		],
 		"gender": "N",
 		"baseStats": {
-				"hp": 90,
+				"hp": 70,
 				"atk": 95,
 				"def": 85,
 				"spa": 55,
@@ -20240,11 +20240,11 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 				"Psychic"
 		],
 		"baseStats": {
-				"hp": 75,
+				"hp": 65,
 				"atk": 50,
-				"def": 80,
+				"def": 70,
 				"spa": 95,
-				"spd": 90,
+				"spd": 80,
 				"spe": 65
 		},
 		"abilities": {


### PR DESCRIPTION
I [previously did this](https://github.com/scoopapa/DH2/commits/main/data/mods/gen3tradebacks/pokedex.ts), but it got overridden by a different commit.