### PR TITLE
FESVUU: Make Steamy Scales damage reductions stack

### DIFF
--- a/data/mods/gen9fe/abilities.ts
+++ b/data/mods/gen9fe/abilities.ts
@@ -2456,8 +2456,14 @@ export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTa
 	},
 	steamyscales: {
 		shortDesc: "Multiscale effects. Damage from Water and Fire is halved.",
+		onSourceBasePowerPriority: 17,
+		onSourceBasePower(basePower, attacker, defender, move) {
+			if (move.type === 'Fire' || move.type === 'Water') {
+				return this.chainModify(0.5);
+			}
+		},
 		onSourceModifyDamage(damage, source, target, move) {
-			if (target.hp >= target.maxhp || ['Water', 'Fire'].includes(move.type)) {
+			if (target.hp >= target.maxhp) {
 				this.debug('Steamy Scales weaken');
 				return this.chainModify(0.5);
 			}


### PR DESCRIPTION
So zxg confirmed that the type-based damage reductions and the Multiscale effect stack