### PR TITLE
Update moves.ts

### DIFF
--- a/data/mods/glacemons/moves.ts
+++ b/data/mods/glacemons/moves.ts
@@ -1292,7 +1292,7 @@ export const Moves: { [moveid: string]: ModdedMoveData; } = {
 			this.attrLastMove('[still]');
 			this.add('-anim', source, "Stone Axe", target);
 		},
-		onModifyBasePower(basePower, source, target, move) {
+		onBasePower(basePower, source, target, move) {
 			if (target.volatiles['disable']) {
 				return this.chainModify(1.5);
 			}


### PR DESCRIPTION
hopefully fixed a syntax error that caused millstone to not deal 1.5x damage on disabled targets