### PR TITLE
Update pokedex.ts

### DIFF
--- a/data/mods/gen3advttp/pokedex.ts
+++ b/data/mods/gen3advttp/pokedex.ts
@@ -141,7 +141,7 @@ export const Pokedex: { [k: string]: ModdedSpeciesData } = {
 
     exeggutor: {
         inherit: true,
-        baseStats: {hp: 95, atk: 95, def: 85, spa: 125, spd: 95, spe: 55},
+        baseStats: {hp: 95, atk: 95, def: 85, spa: 125, spd: 85, spe: 55},
     },
 
     hitmonlee: {


### PR DESCRIPTION
bp asked me to fix this. it was supposed to be +20spdf but it was given +20 from the gen 9 spdf total, which is already 10spdf higher than the adv total, meaning it was +30 spdf.