### PR TITLE
Small Bugfix

### DIFF
--- a/data/mods/gen9crossoverchaosc/moves.ts
+++ b/data/mods/gen9crossoverchaosc/moves.ts
@@ -253,8 +253,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		pp: 1,
 		priority: 0,
 		flags: {},
-		onTryHit(source) {
-			if (!this.canSwitch(source.side)) {
+		onTryHit(source, move) {
+			if (!this.canSwitch(source.side) || !move.selfSwitch) {
 				source.addVolatile('nanoboosted');
 				return this.NOT_FAIL;
 			}


### PR DESCRIPTION
Nano Boost didn't properly handle a certain interaction. This is now fixed!
https://replay.pokemonshowdown.com/dragonheaven-gen9crossoverchaosverc-1-nullpw