### PR TITLE
Smash Mods Brawl: Fix indefinite Dynamaxing

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1857,7 +1857,7 @@ export const Formats: FormatList = [
 			'Arena Trap', 'Moody', 'Sand Veil', 'Shadow Tag', 'Snow Cloak', 'King\'s Rock', 'Razor Fang', 'Baton Pass', 'Last Respects', 'Shed Tail',
 			'Normalium Z', 'Fairium Z', 'Fightinium Z', 'Firium Z', 'Flyinium Z', 'Darkinium Z', 'Dragonium Z', 'Buginium Z', 'Waterium Z', 'Electrium Z',
 			'Ghostium Z', 'Grassium Z', 'Groundium Z', 'Icium Z', 'Poisonium Z', 'Psychium Z', 'Rockium Z', 'Steelium Z', 'Houndoominite',
-			'Wishing Stone', 'Epic Beam', // temp bans
+			/*'Wishing Stone',*/ 'Epic Beam', // temp bans
 		],
 		onValidateTeam(team, format) {
 			/**@type {{[k: string]: true}} */

--- a/data/mods/smashmodsbrawl/conditions.ts
+++ b/data/mods/smashmodsbrawl/conditions.ts
@@ -221,7 +221,7 @@ export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDa
 			pokemon.removeVolatile('dynamax');
 		},
 		onModifyDamage(damage, source, target, move) {
-			if (target.terastallized && ['centiskorch'].includes(target.species.name)) {
+			if (target.terastallized && ['centiskorch','garbodor'].includes(target.species.name)) {
 				return this.chainModify(0.75);
 			}
 		},

--- a/data/mods/smashmodsbrawl/formats-data.ts
+++ b/data/mods/smashmodsbrawl/formats-data.ts
@@ -90,6 +90,7 @@ export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormat
 	},
 	garbodorgmax: {
 		tier: "SSB",
+		isNonstandard: null,
 	},
 	reticannon: {
 		tier: "SSB",

--- a/data/mods/smashmodsbrawl/scripts.ts
+++ b/data/mods/smashmodsbrawl/scripts.ts
@@ -492,7 +492,13 @@ export const Scripts: ModdedBattleScriptsData = {
 		},
 		canDynamaxNow(): boolean {
 			//if (this.battle.gen === 9) return false;
-			return true;
+			// In multi battles, players on a team are alternatingly given the option to dynamax each turn
+			// On turn 1, the players on their team's respective left have the first chance (p1 and p2)
+			if (this.battle.gameType === 'multi' && this.battle.turn % 2 !== [1, 1, 0, 0][this.n]) return false;
+			// if (this.battle.gameType === 'multitriples' && this.battle.turn % 3 !== [1, 1, 2, 2, 0, 0][this.side.n]) {
+			//		return false;
+			// }
+			return !this.dynamaxUsed;
 		},
 		addFishingTokens(amount: number) {
 			if (amount === 0 || Number.isNaN(amount)) return false;


### PR DESCRIPTION
You can now only Dynamax once. (Also things are now more consistent between Garbodor and Centiskorch)
Marked as draft because of the upcoming roomtour